### PR TITLE
Fix vaapi and remove libmfx

### DIFF
--- a/build-stage/Dockerfile
+++ b/build-stage/Dockerfile
@@ -30,7 +30,7 @@ RUN     buildDeps="autoconf \
                    tar \
                    yasm \
                    zlib-dev" && \
-        apk  add --no-cache ${buildDeps} libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0
+        apk  add --no-cache ${buildDeps} libva-dev libdrm-dev libgcc libstdc++ ca-certificates libcrypto1.0 libssl1.0
 
 COPY --from=build-stage ${PREFIX}/bin ${PREFIX}/bin
 COPY --from=build-stage ${PREFIX}/lib ${PREFIX}/lib
@@ -55,7 +55,6 @@ RUN  \
         --enable-libass \
         --enable-libfreetype \
         --enable-libvidstab \
-        --enable-libmfx \
         --enable-libmp3lame \
         --enable-libopenjpeg \
         --enable-libopus \

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -6,7 +6,7 @@ ARG        PREFIX=/usr/local
 ARG        MAKEFLAGS="-j2"
 
 ENV         FDKAAC_VERSION=0.1.5      \
-            LAME_VERSION=3.99.5       \
+            LAME_VERSION=3.100        \
             LIBASS_VERSION=0.13.7     \
             OGG_VERSION=1.3.2         \
             OPENCOREAMR_VERSION=0.1.5 \
@@ -14,7 +14,7 @@ ENV         FDKAAC_VERSION=0.1.5      \
             OPENJPEG_VERSION=2.1.2    \
             THEORA_VERSION=1.1.1      \
             VORBIS_VERSION=1.3.5      \
-            VPX_VERSION=1.7.0         \
+            VPX_VERSION=1.8.0         \
             X264_VERSION=20170226-2245-stable \
             X265_VERSION=2.3          \
             XVID_VERSION=1.3.4        \
@@ -23,7 +23,7 @@ ENV         FDKAAC_VERSION=0.1.5      \
             FONTCONFIG_VERSION=2.12.4 \
             LIBVIDSTAB_VERSION=1.1.0  \
             KVAZAAR_VERSION=1.2.0     \
-            AOM_VERSION=master        \
+            AOM_VERSION=v1.0.0        \
             SRC=/usr/local
 
 ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"


### PR DESCRIPTION
This commit adds libva-dev and libdrm-dev to alpine before building ffmpeg, and removes --enable-libmfx so that ffmpeg builds successfully. 

This does not fix the fact that the build-stage docker cannot complete due to ehendrix23/ffmpeg-alpine:4.0-dependencies not being accessible on Dockerhub.  Have you published that image to dockerhub in a public repository? 